### PR TITLE
Update README.md to reflect status of slack integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A curated list of Awesome Alfred Workflows.
 ## Communication
 - [Adium](http://www.alfredforum.com/topic/1274-adium-workflow/) - Adium workflow to chat with people on your list.
 - [MailTo](https://github.com/deanishe/alfred-mailto) - Quickly compose emails to your contacts and contact groups.
-- [Slack](https://github.com/fspinillo/slackfred) - Alfred workflow to interact, and perform various functions with the service Slack.
+- [Slack](https://github.com/fspinillo/slackfred) - (no longer maintained) Alfred workflow to interact, and perform various functions with the service Slack.
 
 ## Developer
 - [caniuse](https://github.com/willfarrell/alfred-caniuse-workflow) - Caniuse.com workflow to query HTML / CSS support.


### PR DESCRIPTION
Alfred 4 is out - the slack integration has been stale for some time and the repo clearly says author is no longer developing.