### PR TITLE
Removed the invalid Slack workflow URL to a new one

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ A curated list of Awesome Alfred Workflows.
 ## Communication
 - [Adium](http://www.alfredforum.com/topic/1274-adium-workflow/) - Adium workflow to chat with people on your list.
 - [MailTo](https://github.com/deanishe/alfred-mailto) - Quickly compose emails to your contacts and contact groups.
-- [Slack](https://github.com/fspinillo/slackfred) - Alfred workflow to interact, and perform various functions with the service Slack.
+- [Slack](https://github.com/yannickglt/alfred-slack) - Alfred workflow to interact, and perform various functions with the service Slack.
+
 
 ## Developer
 - [caniuse](https://github.com/willfarrell/alfred-caniuse-workflow) - Caniuse.com workflow to query HTML / CSS support.


### PR DESCRIPTION

<img width="315" alt="Screenshot" src="https://user-images.githubusercontent.com/2555503/67979969-67715600-fc43-11e9-8e74-d27d5abf1096.png">
The link given was invalid(Page not found). So I added a new link to another slack workflow.