### PR TITLE
Add Py3 Default Browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ A curated list of Awesome Alfred Workflows.
 ## Web
 - [BugNot](https://github.com/vitorgalvao/alfred-workflows/tree/master/BugNot) - Get logins from bugmenot.
 - [IncognitoClone](https://github.com/vitorgalvao/alfred-workflows/tree/master/IncognitoClone) - Opens Chrome’s frontmost tab in an incognito window.
-- [Py3 Default Browser](https://github.com/wmorland/alfred-py3-default-browser) - Switches your macOS default web browser from Alfred.
+- [Default Browser](https://github.com/wmorland/alfred-py3-default-browser) - Switch the default web browser.
 - [Reddit](https://github.com/deanishe/alfred-reddit) - Search and browse subreddits and hot posts within Alfred.
 
 ## Helpers

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ A curated list of Awesome Alfred Workflows.
 ## Web
 - [BugNot](https://github.com/vitorgalvao/alfred-workflows/tree/master/BugNot) - Get logins from bugmenot.
 - [IncognitoClone](https://github.com/vitorgalvao/alfred-workflows/tree/master/IncognitoClone) - Opens Chrome’s frontmost tab in an incognito window.
-- [Py3 Default Browser](https://github.com/wmorland/alfred-py3-default-browser) - Switches your macOS default browser from Alfred.
+- [Py3 Default Browser](https://github.com/wmorland/alfred-py3-default-browser) - Switches your macOS default web browser from Alfred.
 - [Reddit](https://github.com/deanishe/alfred-reddit) - Search and browse subreddits and hot posts within Alfred.
 
 ## Helpers

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ A curated list of Awesome Alfred Workflows.
 ## Web
 - [BugNot](https://github.com/vitorgalvao/alfred-workflows/tree/master/BugNot) - Get logins from bugmenot.
 - [IncognitoClone](https://github.com/vitorgalvao/alfred-workflows/tree/master/IncognitoClone) - Opens Chrome’s frontmost tab in an incognito window.
+- [Py3 Default Browser](https://github.com/wmorland/alfred-py3-default-browser) - Switches your macOS default browser from Alfred.
 - [Reddit](https://github.com/deanishe/alfred-reddit) - Search and browse subreddits and hot posts within Alfred.
 
 ## Helpers


### PR DESCRIPTION
This adds a workflow for switching the default browser on macOS to the Web category. Web makes the most sense to me but I would also be happy to go with System.