### PR TITLE
Replace Python 2 Gitmoji workflow with standalone Gitmoji workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ A curated list of Awesome Alfred Workflows.
 ## Miscellaneous
 - [Emoji Snippet Pack](http://joelcalifa.com/blog/alfred-emoji-snippet-pack/) - Snippet Pack for Emojis.
 - [Emoj](https://github.com/sindresorhus/alfred-emoj) - Find relevant emoji from text.
-- [Gitmoji](https://github.com/leolabs/alfred-gitmoji/) - Search for [Gitmojis](https://gitmoji.carloscuesta.me/) easily.
+- [Gitmoji](https://github.com/techouse/alfred-gitmoji) - Search for [Gitmojis](https://gitmoji.dev) easily.
 - [Lorem Ipsum](https://github.com/raarellano/alfred-lorem-ipsum-workflow) - Generate lorem ipsum(...) text from Alfred.
 - [Kaomoji](https://github.com/vinkla/alfred-kaomoji) - Find relevant kaomoji from text.
 - [Moment](https://github.com/perfectworks/alfred-workflow-moment) - Advanced time utility, inspired by [moment.js](https://momentjs.com).


### PR DESCRIPTION
Hi,

I love the original [leolabs/alfred-gitmoji](https://github.com/leolabs/alfred-gitmoji) workflow but [since macOS 12 removed Python 2](https://developer.apple.com/documentation/macos-release-notes/macos-12_3-release-notes#Python) it's been affected by https://github.com/deanishe/alfred-workflow/issues/182.

So I decided to bite the bullet and recreate it in Dart [because it can be compiled into a standalone executable](https://dart.dev/tools/dart-compile) eliminating the need for any external prerequisites.

The generated binary is signed and notarized by Apple.

