### PR TITLE
Add Alfred Workflow Dart library

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ A curated list of Awesome Alfred Workflows.
 
 ## Helpers
 - [Alfred-Workflow](https://github.com/deanishe/alfred-workflow) - Python Library for writing Alfred workflows.
+- [Alfred Workflow (for Dart)](https://github.com/techouse/alfred_workflow) - Dart library for writing Alfred workflows. Inspired by [Alfred-Workflow](https://github.com/deanishe/alfred-workflow) for Python.
 - [Alfy](https://github.com/sindresorhus/alfy) - Node.js library to create Alfred workflows with ease.
 - [AwGo](https://github.com/deanishe/awgo) - Full-featured library for Go to build lightning-fast workflows in a jiffy.
 - [Fuzzy Search](https://github.com/deanishe/alfred-fuzzy) - Add fuzzy search to any Script Filter.


### PR DESCRIPTION
A helper library in Dart for authors of workflows for [Alfred](https://www.alfredapp.com/).

I wrote this helper library in Dart when I decided to migrate all my existing Alfred Workflows from Python 2 to standalone binaries.

This library is heavily inspired by the excellent Python library [deanishe/alfred-workflow](https://github.com/deanishe/alfred-workflow).

In its current state, it is very basic and only implements the [Alfred Script Filter JSON API](https://www.alfredapp.com/help/workflows/inputs/script-filter/json/).

### A couple of my Alfred Workflows built using this library

- [alfred-flutter-docs](https://github.com/techouse/alfred-flutter-docs)
- [alfred-dart-docs](https://github.com/techouse/alfred-dart-docs)
- [alfred-react-docs](https://github.com/techouse/alfred-react-docs)
- [alfred-vue-docs](https://github.com/techouse/alfred-vue-docs)
- [alfred-tailwindcss-docs](https://github.com/techouse/alfred-tailwindcss-docs)
- [alfred-django-docs](https://github.com/techouse/alfred-django-docs)
- [alfred-flask-docs](https://github.com/techouse/alfred-flask-docs)
- [alfred-laravel-docs](https://github.com/techouse/alfred-laravel-docs)
- [alfred-nova-docs](https://github.com/techouse/alfred-nova-docs)
- [alfred-cakephp-docs](https://github.com/techouse/alfred-cakephp-docs)
- [alfred-gitmoji](https://github.com/techouse/alfred-gitmoji) (already submitted in #79)