### PR TITLE
Replace Python 2 Convert workflow with standalone Convert workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ A curated list of Awesome Alfred Workflows.
 - [VSCodeDiff](https://github.com/logicxd/alfred-vscodediff) - Show the diff of the last 2 items in clipboard history using VSCode.
 
 ## Scientific
-- [Convert](https://github.com/deanishe/alfred-convert) - Offline conversion of units and (crypto)currencies.
+- [Convert](https://github.com/techouse/alfred-convert) - Offline conversion of units and currencies.
 - [DOITools](https://github.com/hbuschme/doi-tools-alfred-workflow/) - Tools to resolve, open, shorten DOI numbers and even convert them to bibtex.
 - [Scientific Workflow](https://github.com/andrewning/alfred-workflows-scientific) - Workflows that are useful for scientists: e.g. LaTeX, importing references in bibtex.
 - [Skim remote](http://www.packal.org/workflow/skim-remote) - Controls the [Skim PDF Viewer](http://skim-app.sourceforge.net) remotely from Alfred.


### PR DESCRIPTION
The original [deanishe/alfred-convert](https://github.com/deanishe/alfred-convert) is amazing, but ever since [macOS 12.3 removed Python 2](https://developer.apple.com/documentation/macos-release-notes/macos-12_3-release-notes#Python) it's been affected by https://github.com/deanishe/alfred-convert/issues/91.

Realizing that, I decided to [write my own using Dart](https://github.com/techouse/alfred-convert) and compile it to a standalone native binary.

It converts physical units and fiat currencies, however, it does not convert cryptocurrencies.

The binary is signed and notarized by Apple.