### PR TITLE
Add Tailwind CSS docs workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ A curated list of Awesome Alfred Workflows.
 - [Package Managers](https://github.com/willfarrell/alfred-pkgman-workflow) - Package Repo Search.
 - [Packagist](https://github.com/vinkla/alfred-packagist) - Search for PHP packages with [Packagist](https://packagist.org).
 - [Source Tree](https://github.com/zhaocai/alfred2-sourcetree-workflow) - List, search, and open Source Tree repositories.
+- [Tailwind CSS Docs](https://github.com/techouse/alfred-tailwindcss-docs) - Search the [Tailwind CSS](https://tailwindcss.com/docs/) documentation.
 - [VagrantUP](https://github.com/m1keil/alfred-vagrant-workflow) - List and control Vagrant environments with Alfred2.
 - [VSCode](https://github.com/alexchantastic/alfred-open-with-vscode-workflow) - An Alfred 4 workflow opening files or folders with Visual Studio Code.
 


### PR DESCRIPTION
The [Tailwind CSS documentation](https://tailwindcss.com/docs/) is vast and searching it via the website is quite tedious, so I wrote [a workflow that searches it directly from Alfred](https://github.com/techouse/alfred-tailwindcss-docs).

It supports searching all versions of Tailwind CSS, from v0 to v3.

The standalone binary is signed and notarized by Apple.